### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
     icon: 'tag'
     color: 'green'
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'
 outputs:
     tag:


### PR DESCRIPTION
Node 12 is soon to be deprecated for GitHub actions, see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/